### PR TITLE
transpose cholesky decomposition

### DIFF
--- a/R/gp_fit.R
+++ b/R/gp_fit.R
@@ -1,5 +1,4 @@
 
-
 # edit this file for a demo
 
 
@@ -44,7 +43,7 @@ gp_fit <- function(obs, X, pars=c(sigma_n=1, tau=1, l=1), method=c("direct", "se
   
   ## Cholesky simultaneous method.  
   if(method=="cholesky"){
-    L <- chol(K + sigma_n ^ 2 * I)
+    L <- t(chol(K + sigma_n ^ 2 * I))
     alpha <- solve(t(L), solve(L, obs$y))
     loglik <- -.5 * t(obs$y) %*% alpha - sum(log(diag(L))) - n * log(2 * pi) / 2
     k_star <- cov(obs$x, X)


### PR DESCRIPTION
Hey Carl, hope you're having a great weekend and basking in your recent award.

I was looking at your code to help me design my own GP for a side project, and I think I found an error in the cholesky method.  I think there's a discrepancy between how R computes the decomposition and how the formula you're using expects it to be computed.

The help file for `?chol` says

> Note that only the upper triangular part of x is used, so that R'R = x when x is symmetric.

The Appendix to GPML ([page 201](http://www.gaussianprocess.org/gpml/chapters/RWA.pdf)) says that L refers to the lower triangular part of the matrix, however, so that K = LL'

There also seems to be a discrepancy in terms of how you're defining the model outputs for the different methods.  I get an error about `Ef` not being defined when I use `method="cholesky"`.  I assume this is another name for `mu`, but I'm not sure so I didn't make any changes here.

Anyway, hope this is useful.  Please let me know if I'm off-base on any of this.  I want to make sure I understand all of this properly so I can be confident about my own implementation.

Thanks
